### PR TITLE
Separates matches into their own objects.

### DIFF
--- a/Match.js
+++ b/Match.js
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * Match objects.
+ */
+
+var EventEmitter = require('events').EventEmitter;
+
+/**
+ * Match constructor.
+ *
+ * Represents a match in progress.
+ *
+ * @param String language
+ *   The prefered language for team names.
+ */
+var Match = function (language) {
+    this.language = language;
+    this.initialized = false;
+};
+
+Match.prototype = new EventEmitter();
+
+/**
+ * Extracts important data from the match data and updates the match.
+ *
+ * @param Object matchData
+ *   Match object parsed from the FIFA api.
+ */
+Match.prototype.update = function (matchData) {
+    var score = matchData.c_Score;
+    var live = matchData.b_Live;
+    this.data = matchData;
+
+    if (!this.initialized) {
+        this.homeTeam = this.data['c_HomeTeam_' + this.language];
+        this.awayTeam = this.data['c_AwayTeam_' + this.language];
+        this.url = this.data['c_ShareURL_' + this.language];
+        console.log(this.url);
+        this.score = '';
+        this.live = false;
+        this.initialized = true;
+    }
+
+    if (live != this.live) {
+        this[(live ? 'start' : 'end') + 'Match']();
+    } else if (score != this.score) {
+        this.updateScore(score);
+    }
+};
+
+/**
+ * Handles the match starting.
+ *
+ * Sets live to true and emits the startMatch event.
+ */
+Match.prototype.startMatch = function () {
+    console.log("start");
+    this.live = true;
+    this.emit('startMatch', this);
+};
+
+/**
+ * Handles the match ending.
+ *
+ * Sets live to false and emits the endMatch event.
+ */
+Match.prototype.endMatch = function () {
+    console.log("end");
+    this.live = false;
+    this.emit('endMatch', this);
+};
+
+/**
+ * Handles score changes.
+ *
+ * Updates the internal score and emits the scoreChange event.
+ */
+Match.prototype.updateScore = function (score) {
+    console.log("score");
+    this.score = score;
+    this.emit('updateScore', this);
+};
+
+module.exports = Match;

--- a/bot.js
+++ b/bot.js
@@ -1,17 +1,79 @@
 var requestify = require("requestify");
 var async = require("async");
+var cron = require("cron");
+var Match = require("./Match");
+var activeMatches = {};
 
 // Create an incoming webhook
 var slack = require('slack-notify')(process.env.SLACKHOOK);
+
+// Load configuration.
 var DEFAULT_ICON_URL = 'http://worldcupzones.com/wp-content/uploads/2014/05/the-2014-fifa-world-cup-in46.jpg';
-
-var matchID = "",
-matchScore = "",
-match;
-
 var botName = process.env.BOTNAME || 'WorldCupBot';
+var iconUrl = (process.env.ICON_URL || DEFAULT_ICON_URL);
+var channelName = '#' + (process.env.CHANNEL || 'random');
+var language = process.env.LANGUAGE || 'en';
+var startExpression;
+var stopExpression;
+if (language == 'es') {
+    startExpression = 'Comienza';
+    startExpression = 'Finaliza';
+} else if (language == 'pt') {
+    startExpression = 'Começa';
+    stopExpression = 'Termina';
+} else {
+    startExpression = 'Starts';
+    stopExpression = 'Ends';
+}
 
-var cron = require('cron');
+/**
+ * Wraps text in a slack-formatted link.
+ */
+var slackLink = function (text, url) {
+    return '<' + url + '|' + text + '>';
+};
+
+/**
+ * Sends a message to slack.
+ */
+var announce = function (text) {
+    console.log(text);
+    slack.send({
+        channel: channelName,
+        text: text,
+        username: botName,
+        icon_url: iconUrl,
+    });
+};
+
+/**
+ * Sends a "Match Starting" message to slack.
+ */
+var announceMatchStart = function (match) {
+    var vs = match.homeTeam + ' vs ' + match.awayTeam;
+    var stadium = match.data.c_Stadium + ', ' + match.data.c_City;
+    var text = startExpression + ' ' + slackLink(vs, match.url) + ' (' + stadium + ')';
+    announce(text);
+};
+
+/**
+ * Sends a "Match Complete" message to slack, and stops tracking the match.
+ */
+var announceMatchComplete = function (match) {
+    var vs = match.homeTeam + ' vs ' + match.awayTeam;
+    var stadium = match.data.c_Stadium + ', ' + match.data.c_City;
+    var text = stopExpression + ' ' + slackLink(vs, match.url) + ' (' + stadium + ')';
+    announce(text);
+    delete(activeMatches[match.data.n_MatchID]);
+};
+
+/**
+ * Sends a score summary message to slack.
+ */
+var announceScore = function (match) {
+    announce(match.homeTeam + ' (' + match.score + ') ' + match.awayTeam);
+};
+
 var cronJob = cron.job("*/5 * * * * *", function(){
 
 
@@ -20,72 +82,23 @@ var cronJob = cron.job("*/5 * * * * *", function(){
             var matches = response.getBody().data.group;
 
             async.filter(matches, function(item, callback) {
-               callback (item.b_Live == true);
+               callback (item.b_Live == true || activeMatches[item.n_MatchID]);
 
       }, function(results){
+          for (var i = 0; i < results.length; i += 1) {
+              if (activeMatches[results[i].n_MatchID]) {
+                  match = activeMatches[results[i].n_MatchID];
+              } else {
+                  match = new Match(language);
+                  match.on('startMatch', announceMatchStart);
+                  match.on('endMatch', announceMatchComplete);
+                  match.on('updateScore', announceScore);
+                  activeMatches[results[i].n_MatchID] = match;
+              }
 
-            match = results[0];
-
-            if (typeof match == "object") {
-                  // Got Live Match!
-
-                  var iconUrl = (process.env.ICON_URL || DEFAULT_ICON_URL);
-                  var channelName = '#' + (process.env.CHANNEL || 'random');
-                  var homeTeamField = 'c_HomeTeam_' + (process.env.LANGUAGE || 'en');
-                  var awayTeamField = 'c_AwayTeam_' + (process.env.LANGUAGE || 'en');
-                  var shareUrlField = 'c_ShareURL_' + (process.env.LANGUAGE || 'en');
-                  var startExpression
-                  if (process.env.LANGUAGE == 'es') {
-                        startExpression = 'Comienza';
-                  } else if (process.env.LANGUAGE == 'pt') {
-                        startExpression = 'Começa';
-                  } else {
-                        startExpression = 'Starts';
-                  }
-
-                  if (match.n_MatchID != matchID) {
-                              // New Match just started
-
-                              matchID = match.n_MatchID;
-                              matchScore = ''
-
-                              // Notify New match
-                              var text = startExpression + ' <' + match[shareUrlField] + '|' + match[homeTeamField] + ' vs ' + match[awayTeamField] +
-                                    '> (' + match.c_Stadium + ', ' + match.c_City + ')';
-
-                              console.log(text)
-                              slack.send({
-                                   channel: channelName,
-                                   text: text,
-                                   username: botName,
-                                   icon_url: iconUrl
-                             });
-
-
-                        } else if (matchScore != match.c_Score) {
-                              // Different Score
-
-                              matchScore = match.c_Score
-
-                              var text = match[homeTeamField]+ ' '+match.c_Score+' '+match[awayTeamField]+' ';
-
-                              // Notify goal
-                              console.log(text)
-
-                              slack.send({
-                                   channel: channelName,
-                                   text: text,
-                                   username: botName,
-                                   icon_url: iconUrl
-                             });
-
-                        }
-
-                  }
-
-
-
-            });
+              match.update(results[i]);
+          }
+    });
 
       });
 });


### PR DESCRIPTION
This allows for simultaneous matches, and makes it easier to track more
information about each match. As an example, this commit also adds a
message to be sent at the end of matches.

Works towards sbehrends/Live-WorldCup-Notification-for-Slack#1
